### PR TITLE
add support for simple metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ URL slug.
 
 #### Markup
 
-tblog uses the GoDoc format with a small extension. The grammar could be
+tblog uses the GoDoc format with some small extensions. The grammar could be
 generalized as following:
 
 ```
 Title
+Date: Whenever
+Other article metadata: the whole rest of the line
 
 Paragraph. More sentences.
 

--- a/templates/article.html
+++ b/templates/article.html
@@ -6,7 +6,7 @@
 
 	<title>{{.Title}} - tblog demo</title>
 	<meta property="og:title"       content="{{.Title}}"         />
-	<meta property="og:description" content="{{synopsis .Body}}" />
+	<meta property="og:description" content="{{synopsis .Body | or .Meta.Synopsis .Meta.Summary}}" />
 </head>
 
 <body>
@@ -18,6 +18,7 @@
 
 	<article>
 		<h1>{{ .Title }}</h1>
+		{{ with .Meta.Date }}<p class="date">{{ . }}</p>{{ end }}
 		{{ render .Body }}
 	</article>
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -45,6 +45,7 @@
 <style>
 	a.permalink { color: inherit; }
 	pre { tab-size: 4; }
+	p.date { text-align: right; font-style: italic; opacity: 0.75; font-size: medium; line-height: 1.15; margin-top: -1.15em; }
 </style>
 
 {{ end }}


### PR DESCRIPTION
Article metadata can be provided in `key: value` pairs per line in the first paragraph. The title is still the entirety of the first line. Also added a small date line to the default article template, which will be blank if there is no Date metadata item.